### PR TITLE
Update Grpc.Core to version 2.46.7

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,9 +5,6 @@ env:
 
 on:
   workflow_dispatch:
-        
-  schedule:
-    - cron: "0 0 * * *"
 
 jobs:
 

--- a/Grpc.Core.M1.nuspec
+++ b/Grpc.Core.M1.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>Contrib.Grpc.Core.M1</id>
-    <version>INSERTVERSION</version>
+    <version>2.46.7</version>
     <authors>The gRPC Authors; einari</authors>
     <owners>The gRPC Authors</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -15,11 +15,11 @@
     <repository type="git" url="https://github.com/einari/grpc.core.m1.git" commit="2d6b8f61cfdd1c4d2d7c1aae65a4fbf00e3e0981" />
     <dependencies>
       <group targetFramework=".NETStandard1.5">
-        <dependency id="Grpc.Core" version="INSERTVERSION" exclude="Build,Analyzers" />
+        <dependency id="Grpc.Core" version="2.46.6" exclude="Build,Analyzers" />
         <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.0">
-        <dependency id="Grpc.Core.Api" version="INSERTVERSION" exclude="Build,Analyzers" />
+        <dependency id="Grpc.Core.Api" version="2.46.6" exclude="Build,Analyzers" />
         <dependency id="System.Memory" version="4.5.3" exclude="Build,Analyzers" />
       </group>
     </dependencies>

--- a/README.md
+++ b/README.md
@@ -17,9 +17,13 @@ We want to have the shared libraries, so the `cmake` process should be:
 ```shell
 $ mkdir -p cmake/build
 $ cd cmake/build
-$ cmake ../../ -DBUILD_SHARED_LIBS=ON
-$ make
+$ cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+      -DgRPC_BACKWARDS_COMPATIBILITY_MODE=ON \
+      -DgRPC_XDS_USER_AGENT_IS_CSHARP=ON \
+      ../../
+$ make grpc_csharp_ext
 ```
+Then copy the resulting `libgrpc_csharp_ext.dylib` to the `Grpc.Core.M1` folder and rename it to `libgrpc_csharp_ext.arm64.dylib`.
 
 ## Usage
 


### PR DESCRIPTION
Hello,

I believe both version `2.44.0` and `2.46.6` suffer from the issue described here #2 .

The gRPC Core living on branch [v1.46.x](https://github.com/grpc/grpc/tree/v1.46.x) has been updated to version [1.46.7](https://github.com/grpc/grpc/commit/02384e39185f109bd299eb8482306229967dc970). 
There has been [no 2.46.7 release](https://www.nuget.org/packages/Grpc.Core#versions-body-tab) of the C# implementation of gRPC based on the native gRPC C-core library, but we should still release a version `2.46.7` of the Grpc.Core.M1 package. This would allow us to fix the last broken releases and ensure that Grpc.Core.M1 is up-to-date. The generated dylib is compatible with version `2.46.6` of the C# implementation of gRPC based on the native gRPC C-core library.